### PR TITLE
support multiple client authorization

### DIFF
--- a/authorize.go
+++ b/authorize.go
@@ -86,7 +86,7 @@ func (d *AuthorizeData) IsExpired() bool {
 	return d.IsExpiredAt(time.Now())
 }
 
-// IsExpired is true if authorization expires at time 't'
+// IsExpiredAt is true if authorization expires at time 't'
 func (d *AuthorizeData) IsExpiredAt(t time.Time) bool {
 	return d.ExpireAt().Before(t)
 }
@@ -121,31 +121,44 @@ func (s *Server) HandleAuthorizeRequest(w *Response, r *http.Request) *Authorize
 		HttpRequest: r,
 	}
 
-	// must have a valid client
-	ret.Client, err = w.Storage.GetClient(r.Form.Get("client_id"))
-	if err != nil {
-		w.SetErrorState(E_SERVER_ERROR, "unable to get client", ret.State)
-		w.InternalError = err
-		return nil
+	clientIDs := r.Form["client_id"]
+	comboClient := &ComboClient{
+		Audience: clientIDs,
+		Clients:  make([]Client, 0, len(clientIDs)),
 	}
-	if ret.Client == nil {
-		w.SetErrorState(E_UNAUTHORIZED_CLIENT, "client not found", ret.State)
-		return nil
-	}
-	if ret.Client.GetRedirectURI() == "" {
-		w.SetErrorState(E_UNAUTHORIZED_CLIENT, "client redirect URI not found", ret.State)
-		return nil
-	}
+	for _, id := range clientIDs {
+		// must have a valid client
+		var cl Client
+		cl, err = w.Storage.GetClient(id)
+		if err != nil {
+			w.SetErrorState(E_SERVER_ERROR, "unable to get client", ret.State)
+			w.InternalError = err
+			return nil
+		}
+		if cl == nil {
+			w.SetErrorState(E_UNAUTHORIZED_CLIENT, "client not found", ret.State)
+			return nil
+		}
+		if cl.GetRedirectURI() == "" {
+			w.SetErrorState(E_UNAUTHORIZED_CLIENT, "client redirect URI not found", ret.State)
+			return nil
+		}
+		comboClient.Clients = append(comboClient.Clients, cl)
 
-	// check redirect uri, if there are multiple client redirect uri's
-	// don't set the uri
-	if ret.RedirectUri == "" && FirstUri(ret.Client.GetRedirectURI(), s.Config.RedirectUriSeparator) == ret.Client.GetRedirectURI() {
-		ret.RedirectUri = FirstUri(ret.Client.GetRedirectURI(), s.Config.RedirectUriSeparator)
+		// check redirect uri, if there are multiple client redirect uri's
+		// don't set the uri
+		if ret.RedirectUri == "" && FirstUri(cl.GetRedirectURI(), s.Config.RedirectUriSeparator) == cl.GetRedirectURI() {
+			ret.RedirectUri = FirstUri(cl.GetRedirectURI(), s.Config.RedirectUriSeparator)
+		}
 	}
-
-	if err = ValidateUriList(ret.Client.GetRedirectURI(), ret.RedirectUri, s.Config.RedirectUriSeparator); err != nil {
+	if err = ValidateUriList(comboClient.GetRedirectURI(), ret.RedirectUri, ","); err != nil {
 		w.SetErrorState(E_INVALID_REQUEST, "redirect URI invalid", ret.State)
 		return nil
+	}
+	if len(comboClient.Clients) == 1 {
+		ret.Client = comboClient.Clients[0]
+	} else {
+		ret.Client = comboClient
 	}
 
 	w.SetRedirect(ret.RedirectUri)

--- a/client.go
+++ b/client.go
@@ -1,5 +1,10 @@
 package osin
 
+import (
+	"github.com/AccelByte/go-jose/jwt"
+	"strings"
+)
+
 // Client information
 type Client interface {
 	// Client id
@@ -52,9 +57,59 @@ func (d *DefaultClient) GetUserData() interface{} {
 	return d.UserData
 }
 
-// Implement the ClientSecretMatcher interface
+// ClientSecretMatches implement the ClientSecretMatcher interface
 func (d *DefaultClient) ClientSecretMatches(secret string) bool {
 	return d.Secret == secret
+}
+
+// ComboClient implements osin.Client interface
+// This type of client is intended to handle multiple audience
+// in the token
+type ComboClient struct {
+	Audience jwt.Audience
+	Clients  []Client
+}
+
+// GetID satisfies osin.Client interface.
+func (client *ComboClient) GetID() string {
+	return strings.Join(client.Audience, ",")
+}
+
+// GetSecret satisfies osin.Client interface
+func (client *ComboClient) GetSecret() string {
+	secrets := make([]string, 0, len(client.Clients))
+	for _, c := range client.Clients {
+		secrets = append(secrets, c.GetSecret())
+	}
+	return strings.Join(secrets, ",")
+}
+
+// GetRedirectURI satisfies osin.Client interface
+func (client *ComboClient) GetRedirectURI() string {
+	uris := make([]string, 0, len(client.Clients))
+	for _, c := range client.Clients {
+		uris = append(uris, c.GetRedirectURI())
+	}
+	return strings.Join(uris, ",")
+}
+
+// GetUserData satisfies osin.Client interface
+func (client *ComboClient) GetUserData() interface{} {
+	data := make([]interface{}, 0, len(client.Clients))
+	for _, c := range client.Clients {
+		data = append(data, c.GetUserData())
+	}
+	return data
+}
+
+// ClientSecretMatches satisfies the ClientSecretMatcher interface
+func (client *ComboClient) ClientSecretMatches(secret string) bool {
+	return client.GetSecret() == secret
+}
+
+// ClientIDMatches satisfies the ClientIDMatcher interface
+func (client *ComboClient) ClientIDMatches(id string) bool {
+	return client.Audience.Contains(id)
 }
 
 func (d *DefaultClient) CopyFrom(client Client) {

--- a/response.go
+++ b/response.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 // Data for response output
@@ -128,7 +129,13 @@ func (r *Response) GetRedirectUrl() (string, error) {
 
 	// add parameters
 	for n, v := range r.Output {
-		q.Set(n, fmt.Sprint(v))
+		if n == "client_id" {
+			for _, e := range strings.Split(fmt.Sprint(v), ",") {
+				q.Add(n, e)
+			}
+		} else {
+			q.Add(n, fmt.Sprint(v))
+		}
 	}
 
 	// https://tools.ietf.org/html/rfc6749#section-4.2.2


### PR DESCRIPTION
there are some use cases that requires authorization is done for several client.
the implementation of client in auth request is replaced by new client implementation.