### PR TITLE
chore: refactor osin to generate refresh_expire_in without decoding

### DIFF
--- a/access.go
+++ b/access.go
@@ -664,7 +664,6 @@ func (s *Server) FinishAccessRequest(w *Response, r *http.Request, ar *AccessReq
 			if !ar.SkipSetCookie {
 				AddTokenInCookie(w, ret.RefreshToken, "refresh_token", int64(int32(time.Now().Unix())+ret.RefreshExpireIn))
 			}
-
 		}
 		if ret.Scope != "" {
 			w.Output["scope"] = ret.Scope

--- a/access.go
+++ b/access.go
@@ -50,9 +50,6 @@ type AccessRequest struct {
 	// Refresh Token expiration in seconds. Change if different from default
 	RefreshExpiration int32
 
-	// Extend Refresh Token expiration
-	ExtendRefreshExpiration bool
-
 	// Set if a refresh token should be generated
 	GenerateRefresh bool
 
@@ -201,14 +198,13 @@ func (s *Server) handleAuthorizationCodeRequest(w *Response, r *http.Request) *A
 
 	// generate access token
 	ret := &AccessRequest{
-		Type:              AUTHORIZATION_CODE,
-		Code:              r.Form.Get("code"),
-		CodeVerifier:      r.Form.Get("code_verifier"),
-		RedirectUri:       r.Form.Get("redirect_uri"),
-		GenerateRefresh:   true,
-		Expiration:        s.Config.AccessExpiration,
-		RefreshExpiration: s.Config.RefreshExpiration,
-		HttpRequest:       r,
+		Type:            AUTHORIZATION_CODE,
+		Code:            r.Form.Get("code"),
+		CodeVerifier:    r.Form.Get("code_verifier"),
+		RedirectUri:     r.Form.Get("redirect_uri"),
+		GenerateRefresh: true,
+		Expiration:      s.Config.AccessExpiration,
+		HttpRequest:     r,
 	}
 
 	// "code" is required
@@ -664,9 +660,6 @@ func (s *Server) FinishAccessRequest(w *Response, r *http.Request, ar *AccessReq
 		w.Output["expires_in"] = ret.ExpiresIn
 		if ret.RefreshToken != "" {
 			w.Output["refresh_token"] = ret.RefreshToken
-			if ar.ExtendRefreshExpiration == true {
-				ret.RefreshExpireIn = s.Config.ExtendRefreshExpiration
-			}
 			w.Output["refresh_expires_in"] = ret.RefreshExpireIn
 			if !ar.SkipSetCookie {
 				AddTokenInCookie(w, ret.RefreshToken, "refresh_token", int64(int32(time.Now().Unix())+ret.RefreshExpireIn))

--- a/config.go
+++ b/config.go
@@ -34,6 +34,12 @@ type ServerConfig struct {
 	// Access token expiration in seconds (default 1 hour)
 	AccessExpiration int32
 
+	// Refresh token expiration in seconds (default 1 day)
+	RefreshExpiration int32
+
+	// Extend Refresh token expiration in seconds (default 30 days)
+	ExtendRefreshExpiration int32
+
 	// Token type to return
 	TokenType string
 
@@ -71,6 +77,8 @@ func NewServerConfig() *ServerConfig {
 	return &ServerConfig{
 		AuthorizationExpiration:   250,
 		AccessExpiration:          3600,
+		RefreshExpiration:         86400,
+		ExtendRefreshExpiration:   2592000,
 		TokenType:                 "Bearer",
 		AllowedAuthorizeTypes:     AllowedAuthorizeType{CODE},
 		AllowedAccessTypes:        AllowedAccessType{AUTHORIZATION_CODE},

--- a/config.go
+++ b/config.go
@@ -37,9 +37,6 @@ type ServerConfig struct {
 	// Refresh token expiration in seconds (default 1 day)
 	RefreshExpiration int32
 
-	// Extend Refresh token expiration in seconds (default 30 days)
-	ExtendRefreshExpiration int32
-
 	// Token type to return
 	TokenType string
 
@@ -78,7 +75,6 @@ func NewServerConfig() *ServerConfig {
 		AuthorizationExpiration:   250,
 		AccessExpiration:          3600,
 		RefreshExpiration:         86400,
-		ExtendRefreshExpiration:   2592000,
 		TokenType:                 "Bearer",
 		AllowedAuthorizeTypes:     AllowedAuthorizeType{CODE},
 		AllowedAccessTypes:        AllowedAccessType{AUTHORIZATION_CODE},


### PR DESCRIPTION
this tech debt ticket is a part of effort to refactor Osin lib https://accelbyte.atlassian.net/browse/OS-5830

this changes will affect IAM need some adjustment something like in this branch bitbucket https://bitbucket.org/accelbyte/justice-iam-service/commits/8efd3f788f0b3e340f90b3fba41efbeadb17a184. access_token ExpireIn and refresh token RefreshExpireIn will no longer use value by decoding jwt created by generator.go  